### PR TITLE
Type linking issue fixed with typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "nkn-sdk",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "NKN client and wallet SDK",
   "main": "lib/index.js",
   "exports": {
-    ".": "./lib/index.js",
+    ".": {
+      "import": "./lib/index.js",
+      "types": "./index.d.ts"
+    },
     "./": "./lib/"
   },
   "types": "index.d.ts",


### PR DESCRIPTION
`package.json` has an issue where Typescript wasn't able to pick up types.

To reproduce, you can try importing `nkn-sdk` as per the example into a fresh `create-next-app` project (and running `npm build`). This was the error:
```
next build
  ▲ Next.js 14.2.3

   Creating an optimized production build ...
 ✓ Compiled successfully
   Linting and checking validity of types  ...Failed to compile.

./src/core/p2p/nkn-test.ts:1:45
Type error: Could not find a declaration file for module 'nkn-sdk'. '<project>/node_modules/nkn-sdk/lib/index.js' implicitly has an 'any' type.
  There are types at <project>/node_modules/nkn-sdk/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'nkn-sdk' library may need to update its package.json or typings.

> 1 | import { Client, MultiClient, Wallet } from "nkn-sdk";

error: script "build" exited with code 1
```

Small change to `package.json` fixes it!